### PR TITLE
Persist labeling session state across navigation

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -47,6 +47,20 @@ function App() {
           genieSpaceId={state.genieSpaceId}
           spaceData={state.spaceData}
           selectedQuestions={state.selectedQuestions}
+          // Lifted state
+          currentIndex={state.labelingCurrentIndex}
+          generatedSql={state.labelingGeneratedSql}
+          genieResults={state.labelingGenieResults}
+          expectedResults={state.labelingExpectedResults}
+          correctAnswers={state.labelingCorrectAnswers}
+          feedbackTexts={state.labelingFeedbackTexts}
+          // Actions
+          onSetCurrentIndex={actions.setLabelingCurrentIndex}
+          onSetGeneratedSql={actions.setLabelingGeneratedSql}
+          onSetGenieResult={actions.setLabelingGenieResult}
+          onSetExpectedResult={actions.setLabelingExpectedResult}
+          onSetCorrectAnswer={actions.setLabelingCorrectAnswer}
+          onSetFeedbackText={actions.setLabelingFeedbackText}
           onBack={actions.goToBenchmarks}
         />
       )

--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -10,6 +10,7 @@ import type {
   SectionInfo,
   SectionAnalysis,
   FetchSpaceResponse,
+  SqlExecutionResult,
 } from "@/types"
 import {
   fetchSpace,
@@ -37,6 +38,13 @@ export interface AnalysisState {
   analyzingSection: number | null
   selectedQuestions: string[]
   hasLabelingSession: boolean
+  // Labeling session state (persists across navigation)
+  labelingCurrentIndex: number
+  labelingGeneratedSql: Record<string, string>
+  labelingGenieResults: Record<string, SqlExecutionResult | null>
+  labelingExpectedResults: Record<string, SqlExecutionResult | null>
+  labelingCorrectAnswers: Record<string, boolean | null>
+  labelingFeedbackTexts: Record<string, string>
 }
 
 const initialState: AnalysisState = {
@@ -58,6 +66,13 @@ const initialState: AnalysisState = {
   analyzingSection: null,
   selectedQuestions: [],
   hasLabelingSession: false,
+  // Labeling session state
+  labelingCurrentIndex: 0,
+  labelingGeneratedSql: {},
+  labelingGenieResults: {},
+  labelingExpectedResults: {},
+  labelingCorrectAnswers: {},
+  labelingFeedbackTexts: {},
 }
 
 export function useAnalysis() {
@@ -366,6 +381,68 @@ export function useAnalysis() {
     }))
   }, [])
 
+  // Labeling session actions
+  const setLabelingCurrentIndex = useCallback((index: number) => {
+    setState((prev) => ({ ...prev, labelingCurrentIndex: index }))
+  }, [])
+
+  const setLabelingGeneratedSql = useCallback((questionId: string, sql: string) => {
+    setState((prev) => ({
+      ...prev,
+      labelingGeneratedSql: { ...prev.labelingGeneratedSql, [questionId]: sql },
+    }))
+  }, [])
+
+  const setLabelingGenieResult = useCallback(
+    (questionId: string, result: SqlExecutionResult | null) => {
+      setState((prev) => ({
+        ...prev,
+        labelingGenieResults: { ...prev.labelingGenieResults, [questionId]: result },
+      }))
+    },
+    []
+  )
+
+  const setLabelingExpectedResult = useCallback(
+    (questionId: string, result: SqlExecutionResult | null) => {
+      setState((prev) => ({
+        ...prev,
+        labelingExpectedResults: { ...prev.labelingExpectedResults, [questionId]: result },
+      }))
+    },
+    []
+  )
+
+  const setLabelingCorrectAnswer = useCallback(
+    (questionId: string, answer: boolean | null) => {
+      setState((prev) => ({
+        ...prev,
+        labelingCorrectAnswers: { ...prev.labelingCorrectAnswers, [questionId]: answer },
+      }))
+    },
+    []
+  )
+
+  const setLabelingFeedbackText = useCallback((questionId: string, text: string) => {
+    setState((prev) => ({
+      ...prev,
+      labelingFeedbackTexts: { ...prev.labelingFeedbackTexts, [questionId]: text },
+    }))
+  }, [])
+
+  const clearLabelingSession = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      hasLabelingSession: false,
+      labelingCurrentIndex: 0,
+      labelingGeneratedSql: {},
+      labelingGenieResults: {},
+      labelingExpectedResults: {},
+      labelingCorrectAnswers: {},
+      labelingFeedbackTexts: {},
+    }))
+  }, [])
+
   const reset = useCallback(() => {
     setState(initialState)
   }, [])
@@ -399,6 +476,14 @@ export function useAnalysis() {
       selectAllQuestions,
       deselectAllQuestions,
       clearSpaceData,
+      // Labeling session actions
+      setLabelingCurrentIndex,
+      setLabelingGeneratedSql,
+      setLabelingGenieResult,
+      setLabelingExpectedResult,
+      setLabelingCorrectAnswer,
+      setLabelingFeedbackText,
+      clearLabelingSession,
       reset,
     },
   }


### PR DESCRIPTION
## Summary
- Lift labeling session state from LabelingPage local useState to the useAnalysis hook at App level
- State now persists when navigating between Labeling and Benchmarks pages
- Persisted fields: currentIndex, generatedSql, genieResults, expectedResults, correctAnswers, feedbackTexts

## Test plan
- [x] Start a labeling session and generate SQL for a question
- [x] Navigate to Benchmarks page via "Back to Benchmarks"
- [x] Return to labeling page and verify generated SQL, results, and current index are preserved
- [x] Label a question, navigate away and back, verify label persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)