### PR TITLE
Fix navigation bug: cannot return to Summary/Analysis from Benchmarks

### DIFF
--- a/frontend/src/hooks/useAnalysis.ts
+++ b/frontend/src/hooks/useAnalysis.ts
@@ -364,6 +364,7 @@ export function useAnalysis() {
         currentSectionIndex: firstAnalyzedIndex,
         analysisViewIndex: 0,
         showChecklist: false,
+        optimizeView: null,
       }
     })
   }, [])
@@ -386,7 +387,7 @@ export function useAnalysis() {
   }, [])
 
   const goToSummary = useCallback(() => {
-    setState((prev) => ({ ...prev, phase: "summary", showChecklist: false }))
+    setState((prev) => ({ ...prev, phase: "summary", showChecklist: false, optimizeView: null }))
   }, [])
 
   const goToIngest = useCallback(() => {


### PR DESCRIPTION
## Summary
- Fix navigation bug where users couldn't return to Summary or Analysis pages after navigating to Benchmarks
- Add `optimizeView: null` to `goToAnalysis()` and `goToSummary()` callbacks in useAnalysis.ts
- Ensures phase-based routing takes precedence when navigating between Analyze and Optimize modes

## Test plan
- [x] Load a Genie Space and complete analysis to reach Summary
- [x] Click "Benchmarks" in sidebar
- [x] Click "Analysis" in sidebar → should show Analysis page (not Benchmarks)
- [x] Click "Summary" in sidebar → should show Summary page
- [x] Verify Optimize flow still works: Benchmarks → Labeling → Feedback → Optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)