### PR TITLE
Update Genie schema fields to use new terminology

### DIFF
--- a/docs/checklist-by-schema.md
+++ b/docs/checklist-by-schema.md
@@ -27,10 +27,10 @@ This checklist is organized according to the serialized Genie Space JSON schema 
 - [ ] Key columns have synonyms defined
 - [ ] Synonyms include business terminology, abbreviations, and alternative phrasings users would naturally use
 
-**Example Values / Value Dictionary:**
+**Format Assistance / Entity Matching:**
 
-- [ ] Filterable columns have `get_example_values` enabled
-- [ ] Columns with discrete values have `build_value_dictionary` enabled
+- [ ] Filterable columns have `enable_format_assistance` enabled
+- [ ] Columns with discrete values have `enable_entity_matching` enabled
 
 **Column Exclusions:**
 
@@ -112,7 +112,7 @@ This checklist is organized according to the serialized Genie Space JSON schema 
 ## Summary
 
 | Section | Items |
-|---------|-------|
+| --------- | ------- |
 | `data_sources.tables` | 12 |
 | `data_sources.metric_views` | 2 |
 | `instructions.text_instructions` | 5 |

--- a/docs/genie-space-schema.md
+++ b/docs/genie-space-schema.md
@@ -5,7 +5,7 @@ This document describes the JSON schema for Databricks Genie Space configuration
 ## Root Structure
 
 | Field | Type | Required | Description |
-|-------|------|----------|-------------|
+| ------- | ------ | ---------- | ------------- |
 | `version` | integer | Yes | Schema version number |
 | `config` | object | Yes | Configuration settings including sample questions |
 | `data_sources` | object | Yes | Data source definitions (tables) |
@@ -34,10 +34,10 @@ This document describes the JSON schema for Databricks Genie Space configuration
           {
             "column_name": "string",
             "description": ["string"],
-            "get_example_values": true,
+            "enable_format_assistance": true,
             "exclude": false,
             "synonyms": ["string"],
-            "build_value_dictionary": false
+            "enable_entity_matching": false
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Rename API fields to match current Databricks documentation
- `get_example_values` → `enable_format_assistance`
- `build_value_dictionary` → `enable_entity_matching`

## Test plan
- [x] Verify checklist parser correctly references new field names
- [x] Confirm analysis still works with spaces using new schema format

🤖 Generated with [Claude Code](https://claude.com/claude-code)