### PR TITLE
Update Genie Space docs to align with official Databricks schema

### DIFF
--- a/docs/checklist-by-schema.md
+++ b/docs/checklist-by-schema.md
@@ -12,7 +12,7 @@ This checklist is organized according to the serialized Genie Space JSON schema 
 
 **Table Selection:**
 
-- [ ] Between 1 and 25 tables are configured
+- [ ] Ideally 5 or fewer tables are configured (max 25 supported)
 - [ ] Tables are focused (only necessary tables for intended questions)
 - [ ] Tables are well-annotated with descriptions
 - [ ] Datasets are simplified (prejoined where appropriate, unnecessary columns removed)
@@ -29,7 +29,7 @@ This checklist is organized according to the serialized Genie Space JSON schema 
 
 **Format Assistance / Entity Matching:**
 
-- [ ] Filterable columns have `enable_format_assistance` enabled
+- [ ] Filterable columns leverage prompt matching (automatic) or have `enable_format_assistance` explicitly enabled
 - [ ] Columns with discrete values have `enable_entity_matching` enabled
 
 **Column Exclusions:**
@@ -48,9 +48,10 @@ This checklist is organized according to the serialized Genie Space JSON schema 
 
 ### `text_instructions`
 
-- [ ] At least 1 text instruction exists
+- [ ] Exactly 1 text instruction exists (max 1 allowed per space)
 - [ ] Instructions are focused and minimal (not excessive)
 - [ ] Instructions provide globally-applied context
+- [ ] Clarification triggers follow structure: condition, missing details, required action, example
 - [ ] Business jargon is mapped to standard terminology where needed
 - [ ] SQL examples, metrics, join logic, and filters are moved to their respective sections (not embedded in text instructions)
 
@@ -115,7 +116,7 @@ This checklist is organized according to the serialized Genie Space JSON schema 
 | --------- | ------- |
 | `data_sources.tables` | 12 |
 | `data_sources.metric_views` | 2 |
-| `instructions.text_instructions` | 5 |
+| `instructions.text_instructions` | 6 |
 | `instructions.example_question_sqls` | 7 |
 | `instructions.sql_functions` | 1 |
 | `instructions.join_specs` | 3 |
@@ -123,7 +124,7 @@ This checklist is organized according to the serialized Genie Space JSON schema 
 | `instructions.sql_snippets.expressions` | 2 |
 | `instructions.sql_snippets.measures` | 2 |
 | `benchmarks.questions` | 1 |
-| **Total** | **37** |
+| **Total** | **38** |
 
 ---
 

--- a/docs/genie-space-schema.md
+++ b/docs/genie-space-schema.md
@@ -16,106 +16,186 @@ This document describes the JSON schema for Databricks Genie Space configuration
 
 ```json
 {
-  "version": 1,
+  "version": 2,
   "config": {
     "sample_questions": [
       {
-        "id": "string (hex)",
-        "question": ["string"]
+        "id": "a1b2c3d4e5f60000000000000000000a",
+        "question": ["What were total sales last month?"]
+      },
+      {
+        "id": "b2c3d4e5f6a70000000000000000000b",
+        "question": ["Show top 10 customers by revenue"]
       }
     ]
   },
   "data_sources": {
     "tables": [
       {
-        "identifier": "catalog.schema.table",
-        "description": ["string"],
+        "identifier": "sales.analytics.customers",
+        "description": ["Customer master data including contact information and account details"],
         "column_configs": [
           {
-            "column_name": "string",
-            "description": ["string"],
-            "enable_format_assistance": true,
-            "exclude": false,
-            "synonyms": ["string"],
-            "enable_entity_matching": false
+            "column_name": "customer_id",
+            "description": ["Unique identifier for each customer"],
+            "synonyms": ["cust_id", "account_id"]
+          },
+          {
+            "column_name": "customer_name",
+            "enable_entity_matching": true
+          },
+          {
+            "column_name": "internal_notes",
+            "exclude": true
           }
         ]
+      },
+      {
+        "identifier": "sales.analytics.orders",
+        "description": ["Transactional order data including order date, amount, and customer information"],
+        "column_configs": [
+          {
+            "column_name": "order_date",
+            "enable_format_assistance": true
+          },
+          {
+            "column_name": "region",
+            "enable_format_assistance": true,
+            "enable_entity_matching": true
+          },
+          {
+            "column_name": "status",
+            "enable_format_assistance": true,
+            "enable_entity_matching": true
+          }
+        ]
+      },
+      {
+        "identifier": "sales.analytics.products"
       }
     ],
     "metric_views": [
       {
-        "identifier": "catalog.schema.metric_view",
-        "description": ["string"]
+        "identifier": "sales.analytics.revenue_metrics",
+        "description": ["Pre-aggregated revenue metrics by region and time period"],
+        "column_configs": [
+          {
+            "column_name": "period",
+            "description": ["Time period for the metric (monthly, quarterly, yearly)"],
+            "enable_format_assistance": true
+          }
+        ]
       }
     ]
   },
   "instructions": {
     "text_instructions": [
       {
-        "id": "string (hex)",
-        "content": ["string (markdown)"]
+        "id": "01f0b37c378e1c9100000000000000a1",
+        "content": [
+          "When calculating revenue, sum the order_amount column. ",
+          "When asked about 'last month', use the previous calendar month. ",
+          "Round all monetary values to 2 decimal places."
+        ]
       }
     ],
     "example_question_sqls": [
       {
-        "id": "string (hex)",
-        "question": ["string"],
-        "sql": ["string"],
+        "id": "01f0821116d912db00000000000000b1",
+        "question": ["Show top 10 customers by revenue"],
+        "sql": [
+          "SELECT customer_name, SUM(order_amount) as total_revenue\n",
+          "FROM sales.analytics.orders o\n",
+          "JOIN sales.analytics.customers c ON o.customer_id = c.customer_id\n",
+          "GROUP BY customer_name\n",
+          "ORDER BY total_revenue DESC\n",
+          "LIMIT 10"
+        ]
+      },
+      {
+        "id": "01f099751a3a1df300000000000000b2",
+        "question": ["What were total sales last month"],
+        "sql": [
+          "SELECT SUM(order_amount) as total_sales\n",
+          "FROM sales.analytics.orders\n",
+          "WHERE order_date >= DATE_TRUNC('month', CURRENT_DATE - INTERVAL 1 MONTH)\n",
+          "AND order_date < DATE_TRUNC('month', CURRENT_DATE)"
+        ]
+      },
+      {
+        "id": "01f099751a3a1df300000000000000b3",
+        "question": ["Show sales for a specific region"],
+        "sql": [
+          "SELECT SUM(order_amount) as total_sales\n",
+          "FROM sales.analytics.orders\n",
+          "WHERE region = :region_name"
+        ],
         "parameters": [
           {
-            "name": "string",
-            "type_hint": "STRING | INTEGER | DATE | ...",
-            "description": ["string"]
+            "name": "region_name",
+            "type_hint": "STRING",
+            "description": ["The region to filter by (e.g., 'North America', 'Europe')"],
+            "default_value": {
+              "values": ["North America"]
+            }
           }
         ],
-        "usage_guidance": ["string"]
+        "usage_guidance": ["Use this example when the user asks about sales filtered by a specific geographic region"]
       }
     ],
     "sql_functions": [
       {
-        "id": "string (hex)",
-        "identifier": "catalog.schema.function"
+        "id": "01f0c0b4e815100000000000000000f1",
+        "identifier": "sales.analytics.fiscal_quarter"
       }
     ],
     "join_specs": [
       {
-        "id": "string (hex)",
+        "id": "01f0c0b4e815100000000000000000c1",
         "left": {
-          "identifier": "catalog.schema.table",
-          "alias": "string"
+          "identifier": "sales.analytics.orders",
+          "alias": "orders"
         },
         "right": {
-          "identifier": "catalog.schema.table",
-          "alias": "string"
+          "identifier": "sales.analytics.customers",
+          "alias": "customers"
         },
-        "sql": ["join_condition --rt=RELATIONSHIP_TYPE--"],
-        "comment": ["string"]
+        "sql": ["orders.customer_id = customers.customer_id"],
+        "comment": ["Join orders to customers on customer_id"],
+        "instruction": ["Use this join when you need customer details for order analysis"]
       }
     ],
     "sql_snippets": {
       "filters": [
         {
-          "id": "string (hex)",
-          "sql": ["string"],
-          "display_name": "string",
-          "instruction": ["string"],
-          "synonyms": ["string"]
+          "id": "01f09972e66d100000000000000000d1",
+          "sql": ["orders.order_amount > 1000"],
+          "display_name": "high value orders",
+          "synonyms": ["large orders", "big purchases"],
+          "comment": ["Filters to orders over $1000"],
+          "instruction": ["Use when the user asks about high-value or large orders"]
         }
       ],
       "expressions": [
         {
-          "id": "string (hex)",
-          "sql": ["string"],
-          "display_name": "string",
-          "synonyms": ["string"]
+          "id": "01f09974563a100000000000000000e1",
+          "alias": "order_year",
+          "sql": ["YEAR(orders.order_date)"],
+          "display_name": "year",
+          "synonyms": ["fiscal year", "calendar year"],
+          "comment": ["Extracts the year from order date"],
+          "instruction": ["Use for year-over-year analysis"]
         }
       ],
       "measures": [
         {
-          "id": "string (hex)",
-          "sql": ["string"],
-          "display_name": "string",
-          "instruction": ["string"]
+          "id": "01f09972611f100000000000000000f1",
+          "alias": "total_revenue",
+          "sql": ["SUM(orders.order_amount)"],
+          "display_name": "total revenue",
+          "synonyms": ["revenue", "total sales"],
+          "comment": ["Sum of all order amounts"],
+          "instruction": ["Use this measure for revenue calculations"]
         }
       ]
     }
@@ -123,12 +203,12 @@ This document describes the JSON schema for Databricks Genie Space configuration
   "benchmarks": {
     "questions": [
       {
-        "id": "string (hex)",
-        "question": ["string"],
+        "id": "01f0d0b4e815100000000000000000g1",
+        "question": ["What is the average order value?"],
         "answer": [
           {
             "format": "SQL",
-            "content": ["string"]
+            "content": ["SELECT AVG(order_amount) as avg_order_value\n", "FROM sales.analytics.orders"]
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Update checklist to clarify table count recommendation (5 preferred, 25 max), text_instructions limit (1 per space), and add clarification trigger structure guidance
- Upgrade schema doc to version 2 with concrete examples and all missing fields (default_value, alias, comment, instruction, synonyms)
- Add column_configs support for metric_views

## Test plan
- [x] Review checklist changes against official Databricks Genie best practices
- [x] Verify schema JSON example is valid and matches API response structure
- [x] Confirm checklist parser still extracts items correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)