### PR TITLE
Simplify permission notebook for workspace dir and UC grants

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,21 +121,13 @@ After deploying, you must grant the app's service principal (SP) access to requi
    - Add the SP with **Can Use** permission
    - Update `SQL_WAREHOUSE_ID` in `app.yaml` with your warehouse ID
 
-5. **Grant table access** (for Optimize mode):
+5. **Grant Workspace Directory access** (for Optimize mode):
+   - The SP needs **Can Manage** on the workspace directory where new Genie Spaces will be created (the `GENIE_TARGET_DIRECTORY` path in `app.yaml`)
+
+6. **Grant table access** (for Optimize mode):
    - The SP needs SELECT access to the tables your Genie Space queries
-   - Run the following SQL (replace with your SP name and table paths):
 
-   ```sql
-   -- Grant catalog and schema access
-   GRANT USE CATALOG ON CATALOG your_catalog TO `app-XXXXX [your-app-name]`;
-   GRANT USE SCHEMA ON SCHEMA your_catalog.your_schema TO `app-XXXXX [your-app-name]`;
-
-   -- Grant SELECT on tables (option A: specific tables)
-   GRANT SELECT ON TABLE your_catalog.your_schema.table1 TO `app-XXXXX [your-app-name]`;
-
-   -- Or grant SELECT on entire schema (option B: all tables in schema)
-   GRANT SELECT ON SCHEMA your_catalog.your_schema TO `app-XXXXX [your-app-name]`;
-   ```
+> **Tip:** Steps 5 and 6 can be automated using the `notebooks/grant_app_permissions.py` notebook included in this repo.
 
 ## MLflow Tracing (Optional)
 

--- a/notebooks/grant_app_permissions.py
+++ b/notebooks/grant_app_permissions.py
@@ -3,17 +3,24 @@
 # MAGIC %md
 # MAGIC # GenieRx: Grant App Permissions
 # MAGIC
-# MAGIC This notebook grants the GenieRx Databricks App's **service principal** access to the
-# MAGIC resources it needs. Run through each cell in order after deploying the app.
+# MAGIC This notebook grants the GenieRx Databricks App's **service principal** access to
+# MAGIC resources that require programmatic permission grants. Run through each cell in
+# MAGIC order after deploying the app.
 # MAGIC
 # MAGIC ### Resources configured by this notebook
 # MAGIC
 # MAGIC | Resource | Permission | Required For |
 # MAGIC |----------|-----------|--------------|
-# MAGIC | LLM Serving Endpoint | **Can Query** | Analyze + Optimize |
-# MAGIC | SQL Warehouse | **Can Use** | Optimize mode |
-# MAGIC | Genie Space(s) | **Can Edit** | Analyze + Optimize |
-# MAGIC | Unity Catalog / Schema / Tables | **USE CATALOG**, **USE SCHEMA**, **SELECT** | Optimize mode |
+# MAGIC | Workspace Directory | **Can Manage** | Optimize mode (create new Genie Spaces) |
+# MAGIC | Unity Catalog / Schema | **USE CATALOG**, **USE SCHEMA**, **SELECT** | Optimize mode |
+# MAGIC
+# MAGIC ### Resources to grant via UI
+# MAGIC
+# MAGIC | Resource | Permission | Where |
+# MAGIC |----------|-----------|-------|
+# MAGIC | LLM Serving Endpoint | **Can Query** | Serving > Endpoint > Permissions |
+# MAGIC | SQL Warehouse | **Can Use** | SQL > Warehouse > Permissions |
+# MAGIC | Genie Space(s) | **Can Edit** | Genie Space > Settings |
 # MAGIC
 # MAGIC ### Prerequisites
 # MAGIC
@@ -25,37 +32,22 @@
 # MAGIC %md
 # MAGIC ## Step 1 - Configuration
 # MAGIC
-# MAGIC Fill in the widgets at the top of the notebook, then run each subsequent cell.
+# MAGIC Fill in the variables below, then run each subsequent cell.
 
 # COMMAND ----------
 
-dbutils.widgets.text("app_name", "", "1. App Name (e.g. genie-space-analyzer)")
-dbutils.widgets.text("serving_endpoint", "databricks-claude-sonnet-4-5", "2. LLM Serving Endpoint")
-dbutils.widgets.text("sql_warehouse_id", "", "3. SQL Warehouse ID (Optimize mode)")
-dbutils.widgets.text("genie_space_ids", "", "4. Genie Space IDs (comma-separated)")
-dbutils.widgets.text("catalog_name", "", "5. Unity Catalog Name (Optimize mode)")
-dbutils.widgets.text("schema_name", "", "6. Schema Name (Optimize mode)")
-dbutils.widgets.text("table_names", "", "7. Table Names (comma-separated, or leave blank for all tables in schema)")
+APP_NAME = ""
+WORKSPACE_DIRECTORY = ""
+CATALOG_NAME = ""
+SCHEMA_NAME = ""
 
 # COMMAND ----------
 
-# Collect widget values
-APP_NAME = dbutils.widgets.get("app_name").strip()
-SERVING_ENDPOINT = dbutils.widgets.get("serving_endpoint").strip()
-SQL_WAREHOUSE_ID = dbutils.widgets.get("sql_warehouse_id").strip()
-GENIE_SPACE_IDS = [s.strip() for s in dbutils.widgets.get("genie_space_ids").split(",") if s.strip()]
-CATALOG_NAME = dbutils.widgets.get("catalog_name").strip()
-SCHEMA_NAME = dbutils.widgets.get("schema_name").strip()
-TABLE_NAMES = [t.strip() for t in dbutils.widgets.get("table_names").split(",") if t.strip()]
-
-assert APP_NAME, "App Name is required. Enter it in the widget above."
-print(f"App Name:          {APP_NAME}")
-print(f"Serving Endpoint:  {SERVING_ENDPOINT or '(skipped)'}")
-print(f"SQL Warehouse ID:  {SQL_WAREHOUSE_ID or '(skipped)'}")
-print(f"Genie Space IDs:   {GENIE_SPACE_IDS or '(skipped)'}")
-print(f"Catalog:           {CATALOG_NAME or '(skipped)'}")
-print(f"Schema:            {SCHEMA_NAME or '(skipped)'}")
-print(f"Tables:            {TABLE_NAMES or '(all tables in schema)' if CATALOG_NAME else '(skipped)'}")
+assert APP_NAME, "App Name is required."
+print(f"App Name:             {APP_NAME}")
+print(f"Workspace Directory:  {WORKSPACE_DIRECTORY or '(skipped)'}")
+print(f"Catalog:              {CATALOG_NAME or '(skipped)'}")
+print(f"Schema:               {SCHEMA_NAME or '(skipped)'}")
 
 # COMMAND ----------
 
@@ -68,10 +60,12 @@ from databricks.sdk import WorkspaceClient
 
 w = WorkspaceClient()
 
-# List Databricks Apps and find the matching one
-app_info = w.apps.get(APP_NAME)
-sp_id = app_info.service_principal_id
-assert sp_id, f"Could not find service principal for app '{APP_NAME}'. Ensure the app is deployed."
+# Look up the app's service principal
+app_info = w.api_client.do(method="GET", path=f"/api/2.0/apps/{APP_NAME}")
+sp_id = app_info["service_principal_id"]
+assert (
+    sp_id
+), f"Could not find service principal for app '{APP_NAME}'. Ensure the app is deployed."
 
 # Resolve the service principal name (used by permission and GRANT APIs)
 sp = w.service_principals.get(sp_id)
@@ -85,101 +79,48 @@ print(f"Application ID:         {SP_APP_ID}")
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Step 3 - Grant LLM Serving Endpoint Permission
+# MAGIC ## Step 3 - Grant Workspace Directory Permission
 # MAGIC
-# MAGIC The app calls the LLM endpoint to analyze Genie Space configurations.
-# MAGIC This grants **Can Query** on the serving endpoint.
+# MAGIC Required for **Optimize mode** so the app can create new Genie Spaces in the
+# MAGIC target directory. This grants **Can Manage** on the workspace folder.
 
 # COMMAND ----------
 
-if SERVING_ENDPOINT:
-    from databricks.sdk.service.serving import ServingEndpointAccessControlRequest, ServingEndpointPermissionLevel
-
-    endpoint = w.serving_endpoints.get(SERVING_ENDPOINT)
-    endpoint_id = endpoint.id
-
-    w.serving_endpoints.set_permissions(
-        serving_endpoint_id=endpoint_id,
-        access_control_list=[
-            ServingEndpointAccessControlRequest(
-                service_principal_name=SP_NAME,
-                permission_level=ServingEndpointPermissionLevel.CAN_QUERY,
-            )
-        ],
+if WORKSPACE_DIRECTORY:
+    # Get the object ID of the workspace directory
+    obj_info = w.api_client.do(
+        method="GET",
+        path="/api/2.0/workspace/get-status",
+        body={"path": WORKSPACE_DIRECTORY},
     )
-    print(f"Granted CAN_QUERY on serving endpoint '{SERVING_ENDPOINT}' to {SP_NAME}")
-else:
-    print("Skipped - no serving endpoint specified.")
+    object_id = obj_info["object_id"]
 
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Step 4 - Grant SQL Warehouse Permission
-# MAGIC
-# MAGIC Required for **Optimize mode** to execute benchmark SQL queries.
-# MAGIC This grants **Can Use** on the SQL warehouse.
-
-# COMMAND ----------
-
-if SQL_WAREHOUSE_ID:
-    from databricks.sdk.service.sql import SetRequest, ObjectPermissions, AccessControl, PermissionLevel
-
-    # The permissions API path for SQL warehouses
     w.api_client.do(
         method="PATCH",
-        path=f"/api/2.0/permissions/sql/warehouses/{SQL_WAREHOUSE_ID}",
+        path=f"/api/2.0/permissions/directories/{object_id}",
         body={
             "access_control_list": [
                 {
-                    "service_principal_name": SP_NAME,
-                    "permission_level": "CAN_USE",
+                    "service_principal_name": SP_APP_ID,
+                    "permission_level": "CAN_MANAGE",
                 }
             ]
         },
     )
-    print(f"Granted CAN_USE on SQL warehouse '{SQL_WAREHOUSE_ID}' to {SP_NAME}")
+    print(
+        f"Granted CAN_MANAGE on directory '{WORKSPACE_DIRECTORY}' (ID: {object_id}) to {SP_NAME}"
+    )
 else:
-    print("Skipped - no SQL warehouse ID specified.")
+    print("Skipped - no workspace directory specified.")
 
 # COMMAND ----------
 
 # MAGIC %md
-# MAGIC ## Step 5 - Grant Genie Space Permissions
-# MAGIC
-# MAGIC The app needs **Can Edit** on each Genie Space it will analyze or optimize.
-
-# COMMAND ----------
-
-if GENIE_SPACE_IDS:
-    for space_id in GENIE_SPACE_IDS:
-        try:
-            w.api_client.do(
-                method="PATCH",
-                path=f"/api/2.0/permissions/genie-spaces/{space_id}",
-                body={
-                    "access_control_list": [
-                        {
-                            "service_principal_name": SP_NAME,
-                            "permission_level": "CAN_EDIT",
-                        }
-                    ]
-                },
-            )
-            print(f"Granted CAN_EDIT on Genie Space '{space_id}' to {SP_NAME}")
-        except Exception as e:
-            print(f"WARNING: Could not set permissions on Genie Space '{space_id}': {e}")
-            print(f"  -> Open the Genie Space settings in the UI and add '{SP_NAME}' with 'Can Edit' manually.")
-else:
-    print("Skipped - no Genie Space IDs specified.")
-
-# COMMAND ----------
-
-# MAGIC %md
-# MAGIC ## Step 6 - Grant Unity Catalog Permissions
+# MAGIC ## Step 4 - Grant Unity Catalog Permissions
 # MAGIC
 # MAGIC Required for **Optimize mode** so the app can execute SQL on the tables your
 # MAGIC Genie Space references. This grants **USE CATALOG**, **USE SCHEMA**, and
-# MAGIC **SELECT** via SQL.
+# MAGIC **SELECT** on the schema (inherited by all tables).
 
 # COMMAND ----------
 
@@ -187,25 +128,21 @@ if CATALOG_NAME and SCHEMA_NAME:
     grants_executed = []
 
     # USE CATALOG
-    stmt = f"GRANT USE CATALOG ON CATALOG `{CATALOG_NAME}` TO `{SP_NAME}`"
+    stmt = f"GRANT USE CATALOG ON CATALOG `{CATALOG_NAME}` TO `{SP_APP_ID}`"
     spark.sql(stmt)
     grants_executed.append(stmt)
 
     # USE SCHEMA
-    stmt = f"GRANT USE SCHEMA ON SCHEMA `{CATALOG_NAME}`.`{SCHEMA_NAME}` TO `{SP_NAME}`"
+    stmt = (
+        f"GRANT USE SCHEMA ON SCHEMA `{CATALOG_NAME}`.`{SCHEMA_NAME}` TO `{SP_APP_ID}`"
+    )
     spark.sql(stmt)
     grants_executed.append(stmt)
 
-    # SELECT on tables
-    if TABLE_NAMES:
-        for table in TABLE_NAMES:
-            stmt = f"GRANT SELECT ON TABLE `{CATALOG_NAME}`.`{SCHEMA_NAME}`.`{table}` TO `{SP_NAME}`"
-            spark.sql(stmt)
-            grants_executed.append(stmt)
-    else:
-        stmt = f"GRANT SELECT ON SCHEMA `{CATALOG_NAME}`.`{SCHEMA_NAME}` TO `{SP_NAME}`"
-        spark.sql(stmt)
-        grants_executed.append(stmt)
+    # SELECT on all tables in schema (inherited by all current and future tables)
+    stmt = f"GRANT SELECT ON SCHEMA `{CATALOG_NAME}`.`{SCHEMA_NAME}` TO `{SP_APP_ID}`"
+    spark.sql(stmt)
+    grants_executed.append(stmt)
 
     print("Executed grants:")
     for g in grants_executed:
@@ -229,13 +166,11 @@ print("  GenieRx Permission Setup Complete")
 print("=" * 60)
 print()
 print(f"  App:                {APP_NAME}")
-print(f"  Service Principal:  {SP_NAME}")
+print(f"  Service Principal:  {SP_NAME} ({sp_id})")
 print()
 
 checks = {
-    "LLM Serving Endpoint": bool(SERVING_ENDPOINT),
-    "SQL Warehouse": bool(SQL_WAREHOUSE_ID),
-    "Genie Space(s)": bool(GENIE_SPACE_IDS),
+    "Workspace Directory": bool(WORKSPACE_DIRECTORY),
     "Unity Catalog Grants": bool(CATALOG_NAME and SCHEMA_NAME),
 }
 
@@ -247,12 +182,11 @@ skipped = [r for r, g in checks.items() if not g]
 if skipped:
     print()
     print("  Skipped resources can be configured later by re-running")
-    print("  this notebook with the appropriate widget values.")
+    print("  this notebook with the appropriate values.")
 
 print()
-print("  Next steps:")
-print("    1. Open the app and test with a Genie Space ID.")
-print("    2. If you see 403 errors, verify the permissions above.")
-print("    3. Remember to update app.yaml with SQL_WAREHOUSE_ID")
-print("       and GENIE_TARGET_DIRECTORY if using Optimize mode.")
+print("  Don't forget to grant these via the UI:")
+print("    - LLM Serving Endpoint: Can Query")
+print("    - SQL Warehouse: Can Use")
+print("    - Genie Space(s): Can Edit")
 print()


### PR DESCRIPTION
## Summary

- Refactored `notebooks/grant_app_permissions.py` to focus on grants that benefit from automation: **Workspace Directory** (Can Manage) and **Unity Catalog** (USE CATALOG, USE SCHEMA, SELECT)
- Removed serving endpoint, SQL warehouse, and Genie Space permission steps — these are simpler to grant via the Databricks UI
- Added workspace directory permission (step 5) to README's Grant Permissions section
- Replaced `w.apps.get()` with raw API call for service principal lookup

## Test plan

- [x] Deploy the app and run the notebook in a Databricks workspace
- [x] Verify workspace directory permission is granted correctly
- [x] Verify Unity Catalog grants execute successfully
- [x] Confirm README steps are clear and accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)